### PR TITLE
Add emulate_tty flag to True for loggers

### DIFF
--- a/psdk_wrapper/launch/wrapper.launch.py
+++ b/psdk_wrapper/launch/wrapper.launch.py
@@ -43,6 +43,7 @@ def generate_launch_description():
         executable="psdk_wrapper_node",
         name="psdk_wrapper_node",
         output="screen",
+        emulate_tty=True,
         namespace=namespace,
         parameters=[wrapper_params],
     )


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
 
---
 
## Basic Info
 
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Drone platform tested on | DJI M300 RTK |
 
---
 
## Description of contribution in a few bullet points
* Set flag [emulate_tty](https://github.com/ros2/launch/blob/0f81d987039420036a7153c622b075c993ff1558/launch/launch/actions/execute_process.py#L178) to True for all RCLCPP logging show on terminal.

## Motivation and Context
* When using the launch file to execute the node, all ROS 2 logger doesn't show up on the terminal.