### PR TITLE
Add link_config.json to launcher

### DIFF
--- a/psdk_wrapper/launch/wrapper.launch.py
+++ b/psdk_wrapper/launch/wrapper.launch.py
@@ -7,11 +7,9 @@
 # This is a ROS2 launch file which starts the psdk_wrapper_node,
 # configures it and activates it.
 
-import os
-
 from launch import LaunchDescription
 from launch_ros.substitutions import FindPackageShare
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch.actions import EmitEvent, DeclareLaunchArgument
 from launch_ros.actions import LifecycleNode
 from launch_ros.events.lifecycle import ChangeState
@@ -21,6 +19,7 @@ import launch
 
 
 def generate_launch_description():
+    """Launch the psdk_wrapper_node."""
     # Declare the namespace launch argument
     declare_namespace_cmd = DeclareLaunchArgument(
         "namespace",
@@ -28,13 +27,27 @@ def generate_launch_description():
         description="Namespace of the node",
     )
 
-    namespace = LaunchConfiguration("namespace")
-    # Get wrapper parameters
-    psdk_wrapper_pkg_share = FindPackageShare("psdk_wrapper").find("psdk_wrapper")
-    wrapper_params = os.path.join(
-        psdk_wrapper_pkg_share,
-        "cfg",
-        "psdk_params.yaml",
+    # Declare wrapper parameters
+    psdk_params_default_value = PathJoinSubstitution([
+        FindPackageShare('psdk_wrapper'),
+        'cfg', 'psdk_params.yaml'
+    ])
+    declare_psdk_params_cmd = DeclareLaunchArgument(
+        "psdk_params",
+        default_value=psdk_params_default_value,
+        description="DJI PSDK parameters",
+    )
+
+    # Declare link configuration file path
+    link_config_default_value = PathJoinSubstitution([
+        FindPackageShare('psdk_wrapper'),
+        'cfg', 'link_config.json'
+    ])
+
+    declare_link_config_cmd = DeclareLaunchArgument(
+        "link_config_file_path",
+        default_value=link_config_default_value,
+        description="DJI PSDK link configuration file path",
     )
 
     # Prepare the wrapper node
@@ -43,8 +56,14 @@ def generate_launch_description():
         executable="psdk_wrapper_node",
         name="psdk_wrapper_node",
         output="screen",
-        namespace=namespace,
-        parameters=[wrapper_params],
+        namespace=LaunchConfiguration("namespace"),
+        parameters=[
+            {
+                "link_config_file_path": LaunchConfiguration('link_config_file_path'),
+            },
+            LaunchConfiguration("psdk_params")
+
+        ],
     )
 
     # Configure lifecycle node
@@ -68,6 +87,8 @@ def generate_launch_description():
 
     # Declare Launch options
     ld.add_action(declare_namespace_cmd)
+    ld.add_action(declare_psdk_params_cmd)
+    ld.add_action(declare_link_config_cmd)
     ld.add_action(wrapper_node)
     ld.add_action(wrapper_configure_trans_event)
     ld.add_action(wrapper_activate_trans_event)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
 
---
 
## Basic Info
 
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | #43 |
| Primary OS tested on | Ubuntu |
| Drone platform tested on | DJI M300 RTK |
 
---
 
## Description of contribution in a few bullet points
 
* Add link_config configuration file to ROS 2 parameters in launcher
* Allow users to set psdk params and link config from launcher as:
`ros2 launch psdk_wrapper wrapper.launch.py namespace:=M300 psdk_params:=my_config/psdk_params.yaml link_config_file_path:=my_config/link_config.json`

## Motivation and Context

* Link config file path was never set when use the launcher


 ## How Has This Been Tested?

* Launch node with default parameters and then with specific parameters

## Description of documentation updates required from your changes
 
* Maybe documentation about link configuration is needed
