### PR TITLE
Make the number of init retries as a ros param + update documentation

### DIFF
--- a/docs/documentation/GettingStarted.md
+++ b/docs/documentation/GettingStarted.md
@@ -31,36 +31,39 @@ ros2 launch psdk_wrapper wrapper.launch.py
 
 The following parameters can be configured in the *psdk_wrapper/cfg/psdk_params.yaml* file:
 
-| Parameter             | Data Type | Default Value                      | Comments                                    |
-| --------------------- | --------- | ---------------------------------- | ------------------------------------------- |
-| app_name              | String    | -                                  | Add your App name                           |
-| app_id                | String    | -                                  | Add your App id                             |
-| app_key               | String    | -                                  | Add your App key                            |
-| app_license           | String    | -                                  | Add your App license                        |
-| developer_account     | String    | -                                  | Add your developer account (not mandatory)  |
-| baudrate              | String    | 921600                             | -                                           |
-| hardware_connection   | String    | "DJI_USE_UART_AND_USB_BULK_DEVICE" | Depends on your connection method           |
-| uart_dev_1            | String    | "/dev/dji_serial"                  | As defined in udev rules                    |
-| uart_dev_2            | String    | "/dev/dji_advanced_sensing"        | As defined in udev rules                    |
-| imu_frame             | String    | "psdk_imu_link"                    | -                                           |
-| body_frame            | String    | "psdk_base_link"                   | -                                           |
-| map_frame             | String    | "psdk_map_enu"                     | -                                           |
-| gimbal_frame          | String    | "psdk_gimbal_link"                 | -                                           |
-| data_frequency        | Object    | -                                  | Options are: 1, 5, 10, 50, 100, 200, 400 Hz |
-| - imu                 | Integer   | 100                                | -                                           |
-| - attitude            | Integer   | 100                                | -                                           |
-| - acceleration        | Integer   | 50                                 | -                                           |
-| - velocity            | Integer   | 50                                 | -                                           |
-| - angular_velocity    | Integer   | 100                                | -                                           |
-| - position            | Integer   | 50                                 | -                                           |
-| - gps_data            | Integer   | 1                                  | -                                           |
-| - rtk_data            | Integer   | 1                                  | -                                           |
-| - magnetometer        | Integer   | 50                                 | -                                           |
-| - rc_channels_data    | Integer   | 1                                  | -                                           |
-| - gimbal_data         | Integer   | 1                                  | -                                           |
-| - flight_status       | Integer   | 1                                  | -                                           |
-| - battery_level       | Integer   | 1                                  | -                                           |
-| - control_information | Integer   | 50                                 | -                                           |
+| Parameter                     | Data Type | Default Value                      | Comments                                    |
+| ------------------------------| --------- | ---------------------------------- | ------------------------------------------- |
+| app_name                      | String    | -                                  | Add your App name                           |
+| app_id                        | String    | -                                  | Add your App id                             |
+| app_key                       | String    | -                                  | Add your App key                            |
+| app_license                   | String    | -                                  | Add your App license                        |
+| developer_account             | String    | -                                  | Add your developer account (not mandatory)  |
+| baudrate                      | String    | 921600                             | -                                           |
+| hardware_connection           | String    | "DJI_USE_UART_AND_USB_BULK_DEVICE" | Depends on your connection method           |
+| uart_dev_1                    | String    | "/dev/dji_serial"                  | As defined in udev rules                    |
+| num_of_initialization_retries | Int       | 1                                  | Num of retries to init the PSDK app         |
+| imu_frame                     | String    | "psdk_imu_link"                    | -                                           |
+| body_frame                    | String    | "psdk_base_link"                   | -                                           |
+| map_frame                     | String    | "psdk_map_enu"                     | -                                           |
+| gimbal_frame                  | String    | "psdk_gimbal_link"                 | -                                           |
+| camera_frame                  | String    | "psdk_camera_link"                 | -                                           |
+| publish_transforms            | Bool      |  True                              | Whether to publish transforms or not        |
+| data_frequency                | Object    | -                                  | Options are: 1, 5, 10, 50, 100, 200, 400 Hz |
+| - imu                         | Integer   | 100                                | -                                           |
+| - attitude                    | Integer   | 100                                | -                                           |
+| - acceleration                | Integer   | 50                                 | -                                           |
+| - velocity                    | Integer   | 50                                 | -                                           |
+| - angular_velocity            | Integer   | 100                                | -                                           |
+| - position                    | Integer   | 50                                 | -                                           |
+| - altitude                    | Integer   | 50                                 | -                                           |
+| - gps_data                    | Integer   | 1                                  | -                                           |
+| - rtk_data                    | Integer   | 1                                  | -                                           |
+| - magnetometer                | Integer   | 50                                 | -                                           |
+| - rc_channels_data            | Integer   | 1                                  | -                                           |
+| - gimbal_data                 | Integer   | 1                                  | -                                           |
+| - flight_status               | Integer   | 1                                  | -                                           |
+| - battery_level               | Integer   | 1                                  | -                                           |
+| - control_information         | Integer   | 1                                  | -                                           |
 
 
 

--- a/psdk_wrapper/cfg/psdk_params.yaml
+++ b/psdk_wrapper/cfg/psdk_params.yaml
@@ -11,6 +11,8 @@
       uart_dev_1: "/dev/dji_serial"
       uart_dev_2: "/dev/dji_advanced_sensing"
 
+      num_of_initialization_retries: 3
+
       imu_frame: "psdk_imu_link"
       body_frame: "psdk_base_link"
       map_frame: "psdk_map_enu"

--- a/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
+++ b/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
@@ -1915,8 +1915,8 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
    * correctly and False otherwise.
    */
   bool start_camera_stream(CameraImageCallback callback, void* user_data,
-                                const E_DjiLiveViewCameraPosition payload_index,
-                                const E_DjiLiveViewCameraSource camera_source);
+                           const E_DjiLiveViewCameraPosition payload_index,
+                           const E_DjiLiveViewCameraSource camera_source);
   /**
    * @brief Stops the main camera streaming.
    * @param payload_index select which camera to use to retrieve the streaming.
@@ -1989,6 +1989,7 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
   E_DjiLiveViewCameraSource selected_camera_source_;
   bool publish_camera_transforms_{false};
   bool decode_stream_{true};
+  int num_of_initialization_retries_{0};
 };
 
 /**

--- a/psdk_wrapper/include/psdk_wrapper/psdk_wrapper_utils.hpp
+++ b/psdk_wrapper/include/psdk_wrapper/psdk_wrapper_utils.hpp
@@ -41,7 +41,6 @@
 #define CONTROL_DATA_TOPICS_MAX_FREQ 50
 
 #define GOOD_GPS_SIGNAL_LEVEL 5
-#define MAX_NUMBER_OF_RETRIES 5
 
 namespace psdk_ros2
 {

--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -23,7 +23,8 @@ namespace psdk_ros2
 {
 PSDKWrapper::PSDKWrapper(const std::string &node_name)
     : rclcpp_lifecycle::LifecycleNode(
-          node_name, "", rclcpp::NodeOptions().use_intra_process_comms(true).arguments(
+          node_name, "",
+          rclcpp::NodeOptions().use_intra_process_comms(true).arguments(
               {"--ros-args", "-r",
                node_name + ":" + std::string("__node:=") + node_name}))
 {
@@ -62,6 +63,8 @@ PSDKWrapper::PSDKWrapper(const std::string &node_name)
   declare_parameter("data_frequency.flight_status", 1);
   declare_parameter("data_frequency.battery_level", 1);
   declare_parameter("data_frequency.control_information", 1);
+
+  declare_parameter("num_of_initialization_retries", 1);
 }
 PSDKWrapper::~PSDKWrapper() {}
 
@@ -647,6 +650,9 @@ PSDKWrapper::load_parameters()
         CONTROL_DATA_TOPICS_MAX_FREQ);
     params_.control_information_frequency = CONTROL_DATA_TOPICS_MAX_FREQ;
   }
+
+  get_parameter("num_of_initialization_retries",
+                num_of_initialization_retries_);
 }
 
 bool
@@ -693,7 +699,7 @@ PSDKWrapper::init(T_DjiUserInfo *user_info)
   RCLCPP_INFO(get_logger(), "Init DJI Core...");
   int number_retries = 0;
   T_DjiReturnCode result;
-  while (number_retries < MAX_NUMBER_OF_RETRIES)
+  while (number_retries < num_of_initialization_retries_)
   {
     result = DjiCore_Init(user_info);
     if (result != DJI_ERROR_SYSTEM_MODULE_CODE_SUCCESS)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
 
---
 
## Basic Info
 
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (Closes #IssueNumber) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Drone platform tested on | DJI M300 RTK|
 
---
 
## Description of contribution in a few bullet points
 
* Made the number of retries for the init PSDK application a ros parameter which can be configured in the params file
* Updated documentation accordingly

## Motivation and Context

Making this a parameter gives more flexibility to each user to define the "healing" strategy desired in case of an initialization failure of the PSDK application. 


 ## How Has This Been Tested?

Tested in hardware-in-the-loop with a DJI M300 RTK and a companion computer connected via the OSDK port. 

## Description of documentation updates required from your changes
 
<!-- Added new parameter, so need to add that to default configs and documentation page -->
<!-- I added some capabilities, need to document them -->

---
 
## Future work that may be required in bullet points
 
<!-- I think there might be some optimizations to be made -->
<!-- I see a lot of redundancy in this package -->

## Screenshots (if appropriate):