### PR TITLE
Feat/low speed data transmission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ docs/doxyoutput
 docs/api
 
 .pre-commit-config.yaml
+.vscode/

--- a/psdk_interfaces/CMakeLists.txt
+++ b/psdk_interfaces/CMakeLists.txt
@@ -36,6 +36,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/FlightStatus.msg"
   "msg/RCConnectionStatus.msg"
   "msg/ControlMode.msg"
+  "msg/TransmissionData.msg"
   "srv/CameraGetType.srv"
   "srv/CameraSetExposureModeEV.srv"
   "srv/CameraGetExposureModeEV.srv"

--- a/psdk_interfaces/msg/TransmissionData.msg
+++ b/psdk_interfaces/msg/TransmissionData.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+string data

--- a/psdk_wrapper/CMakeLists.txt
+++ b/psdk_wrapper/CMakeLists.txt
@@ -34,7 +34,7 @@ find_package(std_srvs REQUIRED)
 
 # Add path to FindFFMPEG.cmake and FindLIBUSB.cmake files
 set(PSDK_PATH ${PROJECT_SOURCE_DIR}/../../Payload-SDK)
-set(CMAKE_MODULE_PATH 
+set(CMAKE_MODULE_PATH
 ${PSDK_PATH}/samples/sample_c++/platform/linux/common/3rdparty)
 
 find_package(FFMPEG REQUIRED)
@@ -67,7 +67,7 @@ if (PSDK_LIB)
   message(STATUS "PSDK library found: ${PSDK_LIB}")
 else()
   message(FATAL_ERROR "PSDK library NOT found")
-endif()                                                                                                     
+endif()
 
 if (FFMPEG_FOUND)
     message(STATUS "Found FFMPEG installed in the system")

--- a/psdk_wrapper/CMakeLists.txt
+++ b/psdk_wrapper/CMakeLists.txt
@@ -140,6 +140,7 @@ add_library(psdk_wrapper_libs SHARED
   src/modules/camera.cpp
   src/modules/gimbal.cpp
   src/modules/liveview.cpp
+  src/modules/data_transmission.cpp
   ${DJI_OSAL_PATH}/osal_fs.c
   ${DJI_OSAL_PATH}/osal_socket.c
   ${DJI_OSAL_PATH}/osal.c

--- a/psdk_wrapper/src/modules/data_transmission.cpp
+++ b/psdk_wrapper/src/modules/data_transmission.cpp
@@ -1,0 +1,56 @@
+#include <string>
+#include "psdk_wrapper/psdk_wrapper.hpp"
+
+E_DjiChannelAddress channelAddress = DJI_CHANNEL_ADDRESS_MASTER_RC_APP;
+
+namespace psdk_ros2
+{
+
+T_DjiReturnCode c_ReceiveDataFromMobileCallback(const uint8_t* data, uint16_t len) {
+  return global_ptr_->publish_data_from_mobile(data, len);
+}
+bool
+PSDKWrapper::init_data_transmission()
+{
+  RCLCPP_INFO(get_logger(), "Initiating data_transmission module...");
+  if (DjiLowSpeedDataChannel_Init() != DJI_ERROR_SYSTEM_MODULE_CODE_SUCCESS) {
+    RCLCPP_ERROR(get_logger(), "Could not initialize data_transmission module.");
+    return false;
+  }
+
+  T_DjiReturnCode return_code = DjiLowSpeedDataChannel_RegRecvDataCallback(channelAddress,
+                                                                           c_ReceiveDataFromMobileCallback);
+  if (return_code != DJI_ERROR_SYSTEM_MODULE_CODE_SUCCESS) {
+    RCLCPP_ERROR(get_logger(), "Could not initialize receive data callback.");
+    return false;
+  }
+  return true;
+}
+
+bool PSDKWrapper::deinit_data_transmission()
+{
+  RCLCPP_INFO(get_logger(), "Deinitializing data_transmission module...");
+  if (DjiLowSpeedDataChannel_DeInit() != DJI_ERROR_SYSTEM_MODULE_CODE_SUCCESS) {
+    RCLCPP_ERROR(get_logger(), "Could not deinitialize the data_transmission module.");
+    return false;
+  }
+  return true;
+}
+
+
+
+T_DjiReturnCode PSDKWrapper::publish_data_from_mobile(const uint8_t* data,
+                                           uint16_t len)
+{
+  auto trans_data = std::make_unique<psdk_interfaces::msg::TransmissionData>();
+  // The +1 appears to be neccessary, as otherwise there is an additional byte before the
+  // data starts, that appears to be the length of the data.
+  std::string string_data { (char*) (data+1), len-1 };
+  trans_data->data = string_data;
+  trans_data->header.stamp = this->get_clock()->now();
+  trans_data->header.frame_id = get_optical_frame_id();
+  low_speed_transmission_data_pub_->publish(std::move(trans_data));
+  return DJI_ERROR_SYSTEM_MODULE_CODE_SUCCESS;
+}
+
+}

--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -83,7 +83,7 @@ PSDKWrapper::on_configure(const rclcpp_lifecycle::State &state)
     return CallbackReturn::FAILURE;
   }
   if (!init_telemetry() || !init_flight_control() || !init_camera_manager() ||
-      !init_gimbal_manager() || !init_liveview())
+      !init_gimbal_manager() || !init_liveview() || !init_data_transmission())
   {
     return CallbackReturn::FAILURE;
   }
@@ -834,6 +834,8 @@ PSDKWrapper::initialize_ros_elements()
       "psdk_ros2/altitude_sea_level", 10);
   altitude_barometric_pub_ = create_publisher<std_msgs::msg::Float32>(
       "psdk_ros2/altitude_barometric", 10);
+  low_speed_transmission_data_pub_ = create_publisher<psdk_interfaces::msg::TransmissionData>(
+      "psdk_ros2/low_speed_transmission_data", 10);
 
   RCLCPP_INFO(get_logger(), "Creating subscribers");
   flight_control_generic_sub_ = create_subscription<sensor_msgs::msg::Joy>(
@@ -1131,6 +1133,7 @@ PSDKWrapper::activate_ros_elements()
   home_point_altitude_pub_->on_activate();
   altitude_sl_pub_->on_activate();
   altitude_barometric_pub_->on_activate();
+  low_speed_transmission_data_pub_->on_activate();
 }
 
 void


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
 
---
 
## Basic Info
 
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | N/A (but see #39) |
| Primary OS tested on | Ubuntu |
| Drone platform tested on | Matrice 350 RTK on PSDK 3.8  |
 
---
 
## Description of contribution in a few bullet points

Adds a new module for communication via the low speed data channel from an MSDK based app to the drone. Received information is published by the "psdk_ros2/low_speed_transmission_data" topic as a string.

Also adds .vscode to the gitignore, and removes a couple of instances of trailing whitespace.
 
<!--I added this neat new feature -->
<!-- Also fixed a typo here -->

## Motivation and Context

We would like to have communication between the drone and the RC remote via the PSDK apis, as in the past we have only been using rosbridge (ROS1). See my other issue regarding high speed data channel: #39. We were unable to get high speed transmission working, but we have been able to get the low speed transmission working, so we're making this PR to upstream it.

For context see:
- https://developer.dji.com/doc/payload-sdk-tutorial/en/function-set/basic-function/data-transmission.html
- https://github.com/dji-sdk/Payload-SDK/blob/master/samples/sample_c/module_sample/data_transmission/test_data_transmission.c

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

 ## How Has This Been Tested?

We have tested the changes on a Matrice 350 RTK, connected to a DJI RC Plus. The onboard computer is an Intel NUC.

On the nuc, we ran `ros2 launch psdk_wrapper wrapper.launch.py` to start the wrapper. In a second terminal, we had `ros2 topic echo /wrapper/psdk_ros2/low_speed_transmission_data` running to view the data.

On the RC, we had the MSDK sample application installed (https://github.com/dji-sdk/Mobile-SDK-Android-V5). In the app we selected "Testing Tools > PSDK Test > Open Payload Data Page > External". We then entered text into the field and on pressing send, the text should appear in the `rostopic echo` command running on the NUC.

Additionally, we also had to comment out `init_camera_manager()`, `init_gimbal_manager()` and `init_liveview()` from https://github.com/Yamboy1/psdk_ros2/blob/afd4ff1061fb8b29cd269ceab7b6588d7175925f/psdk_wrapper/src/psdk_wrapper.cpp#L85, as we do not currently have a gimbal or camera plugged into a payload port, but this should not make a difference in this case.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Description of documentation updates required from your changes
 
<!-- Added new parameter, so need to add that to default configs and documentation page -->
<!-- I added some capabilities, need to document them -->
We've just added a new publisher, so this should be the only documentation that needs to be added.
---
 
## Future work that may be required in bullet points

There might be some work required to add support for non text (char*) encoded data sent over the channel.
Additionally there's a small hack (with a comment) that seemed necessary to get around an extra byte at the start of the data. I may have gone about fixing that the wrong way so please have a look at it.
 
<!-- I think there might be some optimizations to be made -->
<!-- I see a lot of redundancy in this package -->

## Screenshots (if appropriate):