### PR TITLE
Add flag to set namespace in TF

### DIFF
--- a/docs/documentation/GettingStarted.md
+++ b/docs/documentation/GettingStarted.md
@@ -45,7 +45,7 @@ The following parameters can be configured in the *psdk_wrapper/cfg/psdk_params.
 | developer_account             | String    | -                                  | Add your developer account (not mandatory)  |
 | baudrate                      | String    | 921600                             | -                                           |
 | num_of_initialization_retries | Int       | 1                                  | Num of retries to init the PSDK app         |
-| add_namespace_to_tf           | Bool      | Add node namespace to TF frames    | Add namespace with '_' before the frame name|
+| tf_frame_prefix               | String    | TF frame prefix                    | Add prefix before the frame name            |
 | imu_frame                     | String    | "psdk_imu_link"                    | -                                           |
 | body_frame                    | String    | "psdk_base_link"                   | -                                           |
 | map_frame                     | String    | "psdk_map_enu"                     | -                                           |

--- a/docs/documentation/GettingStarted.md
+++ b/docs/documentation/GettingStarted.md
@@ -45,6 +45,7 @@ The following parameters can be configured in the *psdk_wrapper/cfg/psdk_params.
 | developer_account             | String    | -                                  | Add your developer account (not mandatory)  |
 | baudrate                      | String    | 921600                             | -                                           |
 | num_of_initialization_retries | Int       | 1                                  | Num of retries to init the PSDK app         |
+| add_namespace_to_tf           | Bool      | Add node namespace to TF frames    | Add namespace with '_' before the frame name|
 | imu_frame                     | String    | "psdk_imu_link"                    | -                                           |
 | body_frame                    | String    | "psdk_base_link"                   | -                                           |
 | map_frame                     | String    | "psdk_map_enu"                     | -                                           |

--- a/psdk_wrapper/cfg/psdk_params.yaml
+++ b/psdk_wrapper/cfg/psdk_params.yaml
@@ -14,6 +14,7 @@
       map_frame: "psdk_map_enu"
       gimbal_frame: "psdk_gimbal_link"
       camera_frame: "psdk_camera_link"
+      add_namespace_to_tf: false
       publish_transforms: true
 
       # Mandatory modules to be initialized. Mark with a true those which you 

--- a/psdk_wrapper/cfg/psdk_params.yaml
+++ b/psdk_wrapper/cfg/psdk_params.yaml
@@ -9,12 +9,12 @@
 
       num_of_initialization_retries: 3
 
+      tf_frame_prefix: ""
       imu_frame: "psdk_imu_link"
       body_frame: "psdk_base_link"
       map_frame: "psdk_map_enu"
       gimbal_frame: "psdk_gimbal_link"
       camera_frame: "psdk_camera_link"
-      add_namespace_to_tf: false
       publish_transforms: true
 
       # Mandatory modules to be initialized. Mark with a true those which you

--- a/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
+++ b/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
@@ -230,12 +230,12 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
     std::string developer_account;
     std::string baudrate;
     std::string link_config_file_path;
+    std::string tf_frame_prefix;
     std::string imu_frame;
     std::string body_frame;
     std::string map_frame;
     std::string gimbal_frame;
     std::string camera_frame;
-    bool add_namespace_to_tf;
     std::string hms_return_codes_path;
     bool publish_transforms;
     int imu_frequency;
@@ -1042,8 +1042,8 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
       const T_DjiDataTimestamp* timestamp);
 
   /**
-   * @brief Retrieves single information of battery with index 1. More information about this topic can be found in the
-   * dji_fc_subscription.h.
+   * @brief Retrieves single information of battery with index 1. More
+   * information about this topic can be found in the dji_fc_subscription.h.
    * @param data pointer to T_DjiFcSubscriptionSingleBatteryInfo data
    * @param data_size size of data. Unused parameter.
    * @param timestamp  timestamp provided by DJI
@@ -1055,8 +1055,8 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
       const T_DjiDataTimestamp* timestamp);
 
   /**
-   * @brief Retrieves single information of battery with index 2. More information about this topic can be found in the
-   * dji_fc_subscription.h.
+   * @brief Retrieves single information of battery with index 2. More
+   * information about this topic can be found in the dji_fc_subscription.h.
    * @param data pointer to T_DjiFcSubscriptionSingleBatteryInfo data
    * @param data_size size of data. Unused parameter.
    * @param timestamp  timestamp provided by DJI
@@ -1778,9 +1778,14 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
       psdk_interfaces::msg::DisplayMode>::SharedPtr display_mode_pub_;
   rclcpp_lifecycle::LifecyclePublisher<
       psdk_interfaces::msg::FlightAnomaly>::SharedPtr flight_anomaly_pub_;
-  rclcpp_lifecycle::LifecyclePublisher<sensor_msgs::msg::BatteryState>::SharedPtr battery_pub_;
-  rclcpp_lifecycle::LifecyclePublisher<psdk_interfaces::msg::SingleBatteryInfo>::SharedPtr single_battery_index1_pub_;
-  rclcpp_lifecycle::LifecyclePublisher<psdk_interfaces::msg::SingleBatteryInfo>::SharedPtr single_battery_index2_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<
+      sensor_msgs::msg::BatteryState>::SharedPtr battery_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<
+      psdk_interfaces::msg::SingleBatteryInfo>::SharedPtr
+      single_battery_index1_pub_;
+  rclcpp_lifecycle::LifecyclePublisher<
+      psdk_interfaces::msg::SingleBatteryInfo>::SharedPtr
+      single_battery_index2_pub_;
   rclcpp_lifecycle::LifecyclePublisher<std_msgs::msg::Float32>::SharedPtr
       height_fused_pub_;
   rclcpp_lifecycle::LifecyclePublisher<
@@ -2047,27 +2052,16 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
    * @param language Language to fetch the return codes in.
    * @return psdk_interfaces::msg::HmsInfoTable
    */
-  psdk_interfaces::msg::HmsInfoTable
-  to_ros2_msg(const T_DjiHmsInfoTable& hms_info_table,
-              const nlohmann::json& codes, const char* language = "en");
+  psdk_interfaces::msg::HmsInfoTable to_ros2_msg(
+      const T_DjiHmsInfoTable& hms_info_table, const nlohmann::json& codes,
+      const char* language = "en");
 
   /**
-   * @brief Method to generate a tf name with the namespace of the node
-   * @param ns namespace of the node
+   * @brief Method to generate a tf adding the tf_prefix to the frame name
    * @param frame_name name of the frame to be transformed
    * @return string with the tf name
    */
-  std::string generate_tf_name(const std::string& ns,
-                               const std::string& frame_name);
-
-  /**
-   * @brief Method to generate a tf name with the namespace of the node
-   * @param node pointer to the node
-   * @param frame_name name of the frame to be transformed
-   * @return string with the tf name
-   */
-  std::string generate_tf_name(rclcpp_lifecycle::LifecycleNode* node,
-                               const std::string frame_name);
+  std::string add_tf_prefix(const std::string& frame_name);
 
   /* Global variables */
   PSDKParams params_;

--- a/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
+++ b/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
@@ -2051,6 +2051,24 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
   to_ros2_msg(const T_DjiHmsInfoTable& hms_info_table,
               const nlohmann::json& codes, const char* language = "en");
 
+  /**
+   * @brief Method to generate a tf name with the namespace of the node
+   * @param ns namespace of the node
+   * @param frame_name name of the frame to be transformed
+   * @return string with the tf name
+   */
+  std::string generate_tf_name(const std::string& ns,
+                               const std::string& frame_name);
+
+  /**
+   * @brief Method to generate a tf name with the namespace of the node
+   * @param node pointer to the node
+   * @param frame_name name of the frame to be transformed
+   * @return string with the tf name
+   */
+  std::string generate_tf_name(rclcpp_lifecycle::LifecycleNode* node,
+                               const std::string frame_name);
+
   /* Global variables */
   PSDKParams params_;
   rclcpp::Node::SharedPtr node_;

--- a/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
+++ b/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
@@ -231,6 +231,7 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
     std::string map_frame;
     std::string gimbal_frame;
     std::string camera_frame;
+    bool add_namespace_to_tf;
     bool publish_transforms;
     int imu_frequency;
     int attitude_frequency;

--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -49,6 +49,7 @@ PSDKWrapper::PSDKWrapper(const std::string &node_name)
   declare_parameter("gimbal_frame", rclcpp::ParameterValue("psdk_gimbal_link"));
   declare_parameter("camera_frame", rclcpp::ParameterValue("psdk_camera_link"));
   declare_parameter("publish_transforms", rclcpp::ParameterValue(true));
+  declare_parameter("add_namespace_to_tf", rclcpp::ParameterValue(false));
 
   declare_parameter("data_frequency.imu", 1);
   declare_parameter("data_frequency.timestamp", 1);
@@ -402,6 +403,20 @@ PSDKWrapper::load_parameters()
     RCLCPP_WARN(get_logger(),
                 "camera_frame param not defined, using default one: %s",
                 params_.camera_frame.c_str());
+  }
+  if (!get_parameter("add_namespace_to_tf", params_.add_namespace_to_tf))
+  {
+    RCLCPP_WARN(get_logger(),
+                "add_namespace_to_tf param not defined, using default one: %s",
+                params_.add_namespace_to_tf ? "true" : "false");
+  }
+  if (params_.add_namespace_to_tf)
+  {
+    params_.imu_frame = std::string(get_namespace()) + "/" + params_.imu_frame;
+    params_.body_frame = std::string(get_namespace()) + "/" + params_.body_frame;
+    params_.map_frame = std::string(get_namespace()) + "/" + params_.map_frame;
+    params_.gimbal_frame = std::string(get_namespace()) + "/" + params_.gimbal_frame;
+    params_.camera_frame = std::string(get_namespace()) + "/" + params_.camera_frame;
   }
   if (!get_parameter("publish_transforms", params_.publish_transforms))
   {

--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -43,13 +43,13 @@ PSDKWrapper::PSDKWrapper(const std::string &node_name)
   declare_parameter("mandatory_modules.camera", rclcpp::ParameterValue(true));
   declare_parameter("mandatory_modules.gimbal", rclcpp::ParameterValue(true));
   declare_parameter("mandatory_modules.liveview", rclcpp::ParameterValue(true));
+  declare_parameter("tf_frame_prefix", rclcpp::ParameterValue(""));
   declare_parameter("imu_frame", rclcpp::ParameterValue("psdk_imu_link"));
   declare_parameter("body_frame", rclcpp::ParameterValue("psdk_base_link"));
   declare_parameter("map_frame", rclcpp::ParameterValue("psdk_map_enu"));
   declare_parameter("gimbal_frame", rclcpp::ParameterValue("psdk_gimbal_link"));
   declare_parameter("camera_frame", rclcpp::ParameterValue("psdk_camera_link"));
   declare_parameter("publish_transforms", rclcpp::ParameterValue(true));
-  declare_parameter("add_namespace_to_tf", rclcpp::ParameterValue(false));
   declare_parameter("hms_return_codes_path", rclcpp::ParameterValue(""));
 
   declare_parameter("data_frequency.imu", 1);
@@ -383,11 +383,11 @@ PSDKWrapper::load_parameters()
   get_parameter("mandatory_modules.liveview", is_liveview_module_mandatory_);
   get_parameter("mandatory_modules.hms", is_hms_module_mandatory_);
 
-  if (!get_parameter("add_namespace_to_tf", params_.add_namespace_to_tf))
+  if (!get_parameter("tf_frame_prefix", params_.tf_frame_prefix))
   {
     RCLCPP_WARN(get_logger(),
-                "add_namespace_to_tf param not defined, using default one: %s",
-                params_.add_namespace_to_tf ? "true" : "false");
+                "tf_frame_prefix param not defined, using default one: %s",
+                params_.tf_frame_prefix.c_str());
   }
   if (!get_parameter("imu_frame", params_.imu_frame))
   {
@@ -395,35 +395,35 @@ PSDKWrapper::load_parameters()
                 "imu_frame param not defined, using default one: %s",
                 params_.imu_frame.c_str());
   }
-  params_.imu_frame = generate_tf_name(this, params_.imu_frame);
+  params_.imu_frame = add_tf_prefix(params_.imu_frame);
   if (!get_parameter("body_frame", params_.body_frame))
   {
     RCLCPP_WARN(get_logger(),
                 "body_frame param not defined, using default one: %s",
                 params_.body_frame.c_str());
   }
-  params_.body_frame = generate_tf_name(this, params_.body_frame);
+  params_.body_frame = add_tf_prefix(params_.body_frame);
   if (!get_parameter("map_frame", params_.map_frame))
   {
     RCLCPP_WARN(get_logger(),
                 "map_frame param not defined, using default one: %s",
                 params_.map_frame.c_str());
   }
-  params_.map_frame = generate_tf_name(this, params_.map_frame);
+  params_.map_frame = add_tf_prefix(params_.map_frame);
   if (!get_parameter("gimbal_frame", params_.gimbal_frame))
   {
     RCLCPP_WARN(get_logger(),
                 "gimbal_frame param not defined, using default one: %s",
                 params_.gimbal_frame.c_str());
   }
-  params_.gimbal_frame = generate_tf_name(this, params_.gimbal_frame);
+  params_.gimbal_frame = add_tf_prefix(params_.gimbal_frame);
   if (!get_parameter("camera_frame", params_.camera_frame))
   {
     RCLCPP_WARN(get_logger(),
                 "camera_frame param not defined, using default one: %s",
                 params_.camera_frame.c_str());
   }
-  params_.camera_frame = generate_tf_name(this, params_.camera_frame);
+  params_.camera_frame = add_tf_prefix(params_.camera_frame);
   if (!get_parameter("publish_transforms", params_.publish_transforms))
   {
     RCLCPP_WARN(get_logger(),
@@ -848,9 +848,11 @@ PSDKWrapper::initialize_ros_elements()
   battery_pub_ =
       create_publisher<sensor_msgs::msg::BatteryState>("psdk_ros2/battery", 10);
   single_battery_index1_pub_ =
-      create_publisher<psdk_interfaces::msg::SingleBatteryInfo>("psdk_ros2/single_battery_index1", 10);
+      create_publisher<psdk_interfaces::msg::SingleBatteryInfo>(
+          "psdk_ros2/single_battery_index1", 10);
   single_battery_index2_pub_ =
-    create_publisher<psdk_interfaces::msg::SingleBatteryInfo>("psdk_ros2/single_battery_index2", 10);
+      create_publisher<psdk_interfaces::msg::SingleBatteryInfo>(
+          "psdk_ros2/single_battery_index2", 10);
   height_fused_pub_ = create_publisher<std_msgs::msg::Float32>(
       "psdk_ros2/height_above_ground", 10);
   angular_rate_body_raw_pub_ =
@@ -1401,8 +1403,7 @@ PSDKWrapper::publish_static_transforms()
       geometry_msgs::msg::TransformStamped tf_H20_zoom;
       tf_H20_zoom.header.stamp = this->get_clock()->now();
       tf_H20_zoom.header.frame_id = params_.camera_frame;
-      tf_H20_zoom.child_frame_id =
-          generate_tf_name(this, "h20_zoom_optical_link");
+      tf_H20_zoom.child_frame_id = add_tf_prefix("h20_zoom_optical_link");
       tf_H20_zoom.transform.translation.x = psdk_utils::T_H20_ZOOM[0];
       tf_H20_zoom.transform.translation.y = psdk_utils::T_H20_ZOOM[1];
       tf_H20_zoom.transform.translation.z = psdk_utils::T_H20_ZOOM[2];
@@ -1415,8 +1416,7 @@ PSDKWrapper::publish_static_transforms()
       geometry_msgs::msg::TransformStamped tf_H20_wide;
       tf_H20_wide.header.stamp = this->get_clock()->now();
       tf_H20_wide.header.frame_id = params_.camera_frame;
-      tf_H20_wide.child_frame_id =
-          generate_tf_name(this, "h20_wide_optical_link");
+      tf_H20_wide.child_frame_id = add_tf_prefix("h20_wide_optical_link");
       tf_H20_wide.transform.translation.x = psdk_utils::T_H20_WIDE[0];
       tf_H20_wide.transform.translation.y = psdk_utils::T_H20_WIDE[1];
       tf_H20_wide.transform.translation.z = psdk_utils::T_H20_WIDE[2];
@@ -1498,25 +1498,9 @@ PSDKWrapper::initialize_psdk_modules()
 }
 
 std::string
-PSDKWrapper::generate_tf_name(const std::string &ns,
-                              const std::string &frame_name)
+PSDKWrapper::add_tf_prefix(const std::string &frame_name)
 {
-  if (!params_.add_namespace_to_tf)
-  {
-    return frame_name;
-  }
-  return ns + "_" + frame_name;
-}
-
-std::string
-PSDKWrapper::generate_tf_name(rclcpp_lifecycle::LifecycleNode *node,
-                              std::string frame_name)
-{
-  if (!params_.add_namespace_to_tf)
-  {
-    return frame_name;
-  }
-  return generate_tf_name(node->get_namespace(), frame_name);
+  return params_.tf_frame_prefix + frame_name;
 }
 
 }  // namespace psdk_ros2

--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -1505,7 +1505,7 @@ PSDKWrapper::generate_tf_name(const std::string &ns,
   {
     return frame_name;
   }
-  return ns + "/" + frame_name;
+  return ns + "_" + frame_name;
 }
 
 std::string


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
 
---
 
## Basic Info
 
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Drone platform tested on | DJI M300 RTK |
 
---
 
## Description of contribution in a few bullet points
 
* Add the flag `add_namespace_to_tf` in `psdk_params.yaml` that allows adding node namespace to TF frames.

## Motivation and Context

This feature is required when working with several drones in a swarm and there's a need to identify the TF frames of each drone. This can be achieved either by using different `psdk_params.yaml` files for each namespace or by creating a custom launcher that declares these parameters. But I think this solution is more user-friendly.