### PR TITLE
Add gimbal base frame

### DIFF
--- a/psdk_wrapper/cfg/psdk_params.yaml
+++ b/psdk_wrapper/cfg/psdk_params.yaml
@@ -12,6 +12,7 @@
       imu_frame: "psdk_imu_link"
       body_frame: "psdk_base_link"
       map_frame: "psdk_map_enu"
+      gimbal_base_frame: "psdk_gimbal_base_link"
       gimbal_frame: "psdk_gimbal_link"
       camera_frame: "psdk_camera_link"
       publish_transforms: true

--- a/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
+++ b/psdk_wrapper/include/psdk_wrapper/psdk_wrapper.hpp
@@ -233,6 +233,7 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
     std::string imu_frame;
     std::string body_frame;
     std::string map_frame;
+    std::string gimbal_base_frame;
     std::string gimbal_frame;
     std::string camera_frame;
     std::string hms_return_codes_path;
@@ -1716,12 +1717,12 @@ class PSDKWrapper : public rclcpp_lifecycle::LifecycleNode
    */
   void publish_dynamic_transforms();
   /**
-   * @brief Method which computes the yaw angle difference between the gimbal
-   * (static frame attached to the robot) and a given camera payload attached to
-   * the gimbal
+   * @brief Method which computes the yaw angle difference between the gimbal base
+   * (static frame attached to the robot) and the gimbal frame (frame attached to the
+   * gimbal).
    * @return the yaw angle difference between these two frames.
    */
-  double get_yaw_gimbal_camera();
+  double get_yaw_gimbal();
 
   /* ROS 2 publishers */
   rclcpp_lifecycle::LifecyclePublisher<

--- a/psdk_wrapper/src/modules/telemetry.cpp
+++ b/psdk_wrapper/src/modules/telemetry.cpp
@@ -873,7 +873,7 @@ PSDKWrapper::gimbal_angles_callback(const uint8_t *data, uint16_t data_size,
    */
   geometry_msgs::msg::Vector3Stamped gimbal_angles_msg;
   gimbal_angles_msg.header.stamp = this->get_clock()->now();
-  gimbal_angles_msg.header.frame_id = params_.gimbal_frame;
+  gimbal_angles_msg.header.frame_id = params_.gimbal_base_frame;
   gimbal_angles_msg.vector.x = psdk_utils::deg_to_rad(gimbal_angles->y);
   gimbal_angles_msg.vector.y = psdk_utils::deg_to_rad(-gimbal_angles->x);
   gimbal_angles_msg.vector.z =

--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -1394,6 +1394,25 @@ PSDKWrapper::publish_static_transforms()
   {
     if (attached_camera_type_ == DJI_CAMERA_TYPE_H20)
     {
+      // Publish TF between Gimbal - H20
+      geometry_msgs::msg::TransformStamped tf_gimbal_H20;
+      tf_gimbal_H20.header.stamp = this->get_clock()->now();
+      tf_gimbal_H20.header.frame_id = params_.gimbal_frame;
+      tf_gimbal_H20.child_frame_id = params_.camera_frame;
+      tf_gimbal_H20.transform.translation.x = psdk_utils::T_M300_GIMBAL_H20[0];
+      tf_gimbal_H20.transform.translation.y = psdk_utils::T_M300_GIMBAL_H20[1];
+      tf_gimbal_H20.transform.translation.z = psdk_utils::T_M300_GIMBAL_H20[2];
+
+      tf2::Quaternion q_gimbal_h20;
+      q_gimbal_h20.setRPY(current_state_.gimbal_angles.vector.x,
+                          current_state_.gimbal_angles.vector.y,
+                          get_yaw_gimbal());
+      tf_gimbal_H20.transform.rotation.x = psdk_utils::Q_NO_ROTATION.getX();
+      tf_gimbal_H20.transform.rotation.y = psdk_utils::Q_NO_ROTATION.getY();
+      tf_gimbal_H20.transform.rotation.z = psdk_utils::Q_NO_ROTATION.getZ();
+      tf_gimbal_H20.transform.rotation.w = psdk_utils::Q_NO_ROTATION.getW();
+      tf_static_broadcaster_->sendTransform(tf_gimbal_H20);
+
       // Publish TF between H20 - Zoom lens
       geometry_msgs::msg::TransformStamped tf_H20_zoom;
       tf_H20_zoom.header.stamp = this->get_clock()->now();
@@ -1447,28 +1466,6 @@ PSDKWrapper::publish_dynamic_transforms()
     tf_gimbal_base_gimbal.transform.rotation.z = q_gimbal.getZ();
     tf_gimbal_base_gimbal.transform.rotation.w = q_gimbal.getW();
     tf_broadcaster_->sendTransform(tf_gimbal_base_gimbal);
-  }
-
-  if (attached_camera_type_ == DJI_CAMERA_TYPE_H20)
-  {
-    // Publish TF between Gimbal - H20
-    geometry_msgs::msg::TransformStamped tf_gimbal_H20;
-    tf_gimbal_H20.header.stamp = this->get_clock()->now();
-    tf_gimbal_H20.header.frame_id = params_.gimbal_frame;
-    tf_gimbal_H20.child_frame_id = params_.camera_frame;
-    tf_gimbal_H20.transform.translation.x = psdk_utils::T_M300_GIMBAL_H20[0];
-    tf_gimbal_H20.transform.translation.y = psdk_utils::T_M300_GIMBAL_H20[1];
-    tf_gimbal_H20.transform.translation.z = psdk_utils::T_M300_GIMBAL_H20[2];
-
-    tf2::Quaternion q_gimbal_h20;
-    q_gimbal_h20.setRPY(current_state_.gimbal_angles.vector.x,
-                        current_state_.gimbal_angles.vector.y,
-                        get_yaw_gimbal());
-    tf_gimbal_H20.transform.rotation.x = psdk_utils::Q_NO_ROTATION.getX();
-    tf_gimbal_H20.transform.rotation.y = psdk_utils::Q_NO_ROTATION.getY();
-    tf_gimbal_H20.transform.rotation.z = psdk_utils::Q_NO_ROTATION.getZ();
-    tf_gimbal_H20.transform.rotation.w = psdk_utils::Q_NO_ROTATION.getW();
-    tf_broadcaster_->sendTransform(tf_gimbal_H20);
   }
 }
 


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
 
---
 
## Basic Info
 
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | - |
| Primary OS tested on | Ubuntu |
| Drone platform tested on | DJI M300 RTK & DJI M350 RTK |
 
---
 
## Description of contribution in a few bullet points
* Added `gimbal_base_frame` frame to establish the origin of the gimbal
* Defined `gimbal_frame` as the current transform of the gimbal relative to its origin `gimbal_base_frame` (the same information provided by the gimbal/angles topic)
* Resulting hierarchy:
drone_base <--static transform--> gimbal base <--dynamic transform--> gimbal <--static transform--> payload
* Added `gimbal_base_frame` parameters to specify the gimbal origin frame name.
* Included transforms for DJI M350 RTK, aligning with those of DJI M300 RTK.

## Motivation and Context
* Necessity to publish gimbal rotation from the origin orientation, independent of the attached device.

 ## How Has This Been Tested?
* Connected to DJI M300 RTK with a H20 payload and validated functionality by moving the gimbal.

## Screenshots (if appropriate):
TF Tree:
![DJI_PSDK_frames](https://github.com/umdlife/psdk_ros2/assets/57761265/f6dde82c-32d9-4adf-8764-b5eee7ae2937)

Rviz:
![DJI_PSDK_frames_rviz](https://github.com/umdlife/psdk_ros2/assets/57761265/4a4f3e9a-65a0-45d6-bc52-228d61ded142)

