### PR TITLE
Clean up node on destructor to be able to reconnect

### DIFF
--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -73,7 +73,11 @@ PSDKWrapper::PSDKWrapper(const std::string &node_name)
 
   declare_parameter("num_of_initialization_retries", 1);
 }
-PSDKWrapper::~PSDKWrapper() {}
+PSDKWrapper::~PSDKWrapper() {
+  RCLCPP_INFO(get_logger(), "Destroying PSDKWrapper");
+  rclcpp_lifecycle::State state;
+  PSDKWrapper::on_shutdown(state);
+}
 
 PSDKWrapper::CallbackReturn
 PSDKWrapper::on_configure(const rclcpp_lifecycle::State &state)


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
 
---
 
## Basic Info
 
| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   |  |
| Primary OS tested on | Ubuntu |
| Drone platform tested on | DJI M300 RTK, DJI M350 RTK |
 
---
 
## Description of contribution in a few bullet points
 
* Call _deinit_ methods when the node is being cleaned up, in the destructor of the Wrapper.

## Motivation and Context

* After the first connection, when I kill the node using SIGINT signal, the drone must be rebooted to reconnect, as the DJI connection is not being cleaned up properly.


 ## How Has This Been Tested?

* On DJI M300 RTK and DJI M350 RTK