### PR TITLE
Disable Landing Gear subscription via config.

### DIFF
--- a/docs/_build/html/documentation/GettingStarted.html
+++ b/docs/_build/html/documentation/GettingStarted.html
@@ -255,6 +255,11 @@ ros2<span class="w"> </span>launch<span class="w"> </span>psdk_wrapper<span clas
 <td><p>1</p></td>
 <td><p>-</p></td>
 </tr>
+<tr class="row-even"><td><p>- landing_gear</p></td>
+<td><p>Integer</p></td>
+<td><p>1</p></td>
+<td><p>-</p></td>
+</tr>
 <tr class="row-odd"><td><p>- control_information</p></td>
 <td><p>Integer</p></td>
 <td><p>50</p></td>

--- a/docs/documentation/GettingStarted.md
+++ b/docs/documentation/GettingStarted.md
@@ -106,6 +106,7 @@ The following parameters can be configured in the *psdk_wrapper/cfg/psdk_params.
 | - gimbal_data                 | Integer   | 1                                  | -                                           |
 | - flight_status               | Integer   | 1                                  | -                                           |
 | - battery_level               | Integer   | 1                                  | -                                           |
+| - landing_gear                | Integer   | 0                                  | -                                           |
 | - control_information         | Integer   | 1                                  | -                                           |
 | - esc_data_frequency          | Integer   | 1                                  | -                                           |
 

--- a/psdk_wrapper/cfg/psdk_params.yaml
+++ b/psdk_wrapper/cfg/psdk_params.yaml
@@ -50,5 +50,6 @@
         gimbal_data: 1
         flight_status: 1
         battery_level: 1
+        landing_gear: 0
         control_information: 1
         esc_data_frequency: 1

--- a/psdk_wrapper/include/psdk_wrapper/modules/telemetry.hpp
+++ b/psdk_wrapper/include/psdk_wrapper/modules/telemetry.hpp
@@ -307,6 +307,7 @@ class TelemetryModule : public rclcpp_lifecycle::LifecycleNode
     int gimbal_data_frequency;
     int flight_status_frequency;
     int battery_level_frequency;
+    int landing_gear_frequency;
     int control_information_frequency;
     int esc_data_frequency;
   };

--- a/psdk_wrapper/src/modules/telemetry.cpp
+++ b/psdk_wrapper/src/modules/telemetry.cpp
@@ -2303,19 +2303,6 @@ TelemetryModule::subscribe_psdk_topics()
                    return_code);
     }
     return_code = DjiFcSubscription_SubscribeTopic(
-        DJI_FC_SUBSCRIPTION_TOPIC_STATUS_LANDINGGEAR,
-        get_frequency(params_.flight_status_frequency),
-        c_landing_gear_status_callback);
-
-    if (return_code != DJI_ERROR_SYSTEM_MODULE_CODE_SUCCESS)
-    {
-      RCLCPP_ERROR(get_logger(),
-                   "Could not subscribe successfully to topic "
-                   "DJI_FC_SUBSCRIPTION_TOPIC_STATUS_LANDINGGEAR, error %ld",
-                   return_code);
-    }
-
-    return_code = DjiFcSubscription_SubscribeTopic(
         DJI_FC_SUBSCRIPTION_TOPIC_STATUS_MOTOR_START_ERROR,
         get_frequency(params_.flight_status_frequency),
         c_motor_start_error_callback);
@@ -2338,6 +2325,22 @@ TelemetryModule::subscribe_psdk_topics()
       RCLCPP_ERROR(get_logger(),
                    "Could not subscribe successfully to topic "
                    "DJI_FC_SUBSCRIPTION_TOPIC_FLIGHT_ANOMALY, error %ld",
+                   return_code);
+    }
+  }
+
+  if (params_.landing_gear_frequency > 0)
+  {
+    return_code = DjiFcSubscription_SubscribeTopic(
+        DJI_FC_SUBSCRIPTION_TOPIC_STATUS_LANDINGGEAR,
+        get_frequency(params_.landing_gear_frequency),
+        c_landing_gear_status_callback);
+
+    if (return_code != DJI_ERROR_SYSTEM_MODULE_CODE_SUCCESS)
+    {
+      RCLCPP_ERROR(get_logger(),
+                   "Could not subscribe successfully to topic "
+                   "DJI_FC_SUBSCRIPTION_TOPIC_STATUS_LANDINGGEAR, error %ld",
                    return_code);
     }
   }

--- a/psdk_wrapper/src/psdk_wrapper.cpp
+++ b/psdk_wrapper/src/psdk_wrapper.cpp
@@ -84,6 +84,7 @@ PSDKWrapper::PSDKWrapper(const std::string &node_name)
   declare_parameter("data_frequency.gimbal_data", 1);
   declare_parameter("data_frequency.flight_status", 1);
   declare_parameter("data_frequency.battery_level", 1);
+  declare_parameter("data_frequency.landing_gear", 1);
   declare_parameter("data_frequency.control_information", 1);
   declare_parameter("data_frequency.esc_data_frequency", 1);
   declare_parameter("num_of_initialization_retries", 1);
@@ -588,6 +589,10 @@ PSDKWrapper::load_parameters()
         "data_frequency.battery_level",
         telemetry_module_->params_.battery_level_frequency,
         BATTERY_STATUS_TOPICS_MAX_FREQ);
+    get_and_validate_frequency(
+        "data_frequency.landing_gear",
+        telemetry_module_->params_.landing_gear_frequency,
+        FLIGHT_STATUS_TOPICS_MAX_FREQ);
     get_and_validate_frequency(
         "data_frequency.control_information",
         telemetry_module_->params_.control_information_frequency,


### PR DESCRIPTION
#### **Note:** Enabling it can cause communication errors on PSDK 3.8.1-3.11.1

This pull request introduces a new parameter, **`landing_gear_frequency`**, to the PSDK wrapper, enabling independent control over the subscription frequency of the landing gear status topic (**`DJI_FC_SUBSCRIPTION_TOPIC_STATUS_LANDINGGEAR`**). Previously, this topic was subscribed using the flight_status_frequency parameter.

### Changes

* Added landing_gear_frequency parameter: Included in the configuration files (**`psdk_params.yaml`**) and documentation (**`GettingStarted.md`** and **`GettingStarted.html`**).
* Updated telemetry subscription logic: The **`TelemetryModule`** now uses **`landing_gear_frequency`** to conditionally subscribe to the landing gear status topic, only subscribing if the frequency is greater than 0.
* Parameter loading and validation: Added support for the new parameter in **`psdk_wrapper.cpp`**, with a default value of 0 in the config file.